### PR TITLE
Don't assume `hasOwnProperty` is safe

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ exports.scan = function (obj, options) {
         next = [];
 
         for (const node of nodes) {
-            if (node.hasOwnProperty('__proto__')) {
+            if (Object.prototype.hasOwnProperty.call(node, '__proto__')) {
                 if (options.protoAction !== 'remove') {
                     throw new SyntaxError('Object contains forbidden prototype property');
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 const internals = {
     suspectRx: /"(?:_|\\u005f)(?:_|\\u005f)(?:p|\\u0070)(?:r|\\u0072)(?:o|\\u006f)(?:t|\\u0074)(?:o|\\u006f)(?:_|\\u005f)(?:_|\\u005f)"\s*\:/
@@ -65,7 +66,7 @@ exports.scan = function (obj, options) {
         next = [];
 
         for (const node of nodes) {
-            if (Object.prototype.hasOwnProperty.call(node, '__proto__')) {
+            if (hasOwnProperty.call(node, '__proto__')) {
                 if (options.protoAction !== 'remove') {
                     throw new SyntaxError('Object contains forbidden prototype property');
                 }

--- a/test/index.js
+++ b/test/index.js
@@ -127,5 +127,14 @@ describe('Bourne', () => {
 
             expect(() => Bourne.scan(obj)).to.throw(SyntaxError);
         });
+
+        it('does not break when hasOwnProperty is overwritten', () => {
+
+            const text = '{ "a": 5, "b": 6, "hasOwnProperty": "text", "__proto__": { "x": 7 } }';
+            const obj = JSON.parse(text);
+
+            Bourne.scan(obj, { protoAction: 'remove' });
+            expect(obj).to.equal({ a: 5, b: 6, hasOwnProperty: 'text' });
+        });
     });
 });


### PR DESCRIPTION
It's not safe to use `hasOwnProperty` on an object that came from `JSON.parse()`, since it may have been overwritten, as it is here:

```json
{ "hasOwnProperty": "boom", "__proto__": { "foo": "bar" } }
````

Calling `node.hasOwnProperty('__proto__')` on this object results in a `TypeError` since `hasOwnProperty` is a string and not a function.