### PR TITLE
Support node v18, drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v3
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2019-2020, Sideway Inc, and project contributors  
+Copyright (c) 2019-2022, Project contributors
+Copyright (c) 2019-2020, Sideway Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     ]
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "9.x.x",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
+    "@hapi/lab": "25.0.0-beta.1",
     "@types/node": "^17.0.31",
     "benchmark": "2.x.x",
     "typescript": "^4.6.3"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ]
   },
   "devDependencies": {
-    "@hapi/code": "9.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
     "@hapi/lab": "25.0.0-beta.1",
     "@types/node": "^17.0.31",


### PR DESCRIPTION
 - Test on node v14+.
 - Update node v18-compatible versions of lab and code.

If this looks good, this will go out as bourne v3.